### PR TITLE
Hand specify CLI's version of solana web3.js to patch level

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,7 @@
     "@solana/web3.js": "~1.32.1",
     "bs58": "^4.0.1",
     "commander": "^8.3.0",
-    "rly-js": "^0.0.9"
+    "rly-js": "^0.0.11"
   },
   "devDependencies": {
     "@types/chai": "^4.3.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,6 +25,7 @@
     "@metaplex/js": "^4.10.1",
     "@project-serum/anchor": "^0.22.1",
     "@solana/spl-token": "^0.1.8",
+    "@solana/web3.js": "~1.32.1",
     "bs58": "^4.0.1",
     "commander": "^8.3.0",
     "rly-js": "^0.0.9"


### PR DESCRIPTION
Fun little lerna + npm + solana perfect storm was resulting in the CLI
saying it wanted/needed web3.js@1.42 which was breaking all the other
packages codes which needed 1.32.X version of web3.js.

Making the dep explicit and set with a "~" for patch level specificity
means lerna now hoists 1.32 for all the packages and everything is right
in the world
