### PR TITLE
Run test suite as part of CI flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,4 @@ jobs:
       run: lerna run tsc
 
     - name: Run Test Suite
-      run: lerna run test
+      run: lerna run test-all-js-library

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,6 @@ jobs:
 
     - name: Compile Typescript packages
       run: lerna run tsc
+
+    - name: Run Test Suite
+      run: lerna run test

--- a/packages/ts/package.json
+++ b/packages/ts/package.json
@@ -5,11 +5,12 @@
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",
   "scripts": {
-    "test": "./node_modules/ts-mocha/bin/ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts",
-    "test-cs": "./node_modules/ts-mocha/bin/ts-mocha -p ./tsconfig.json -t 1000000 tests/test.canSwap.ts",
-    "test-tbc": "./node_modules/ts-mocha/bin/ts-mocha -p ./tsconfig.json -t 1000000 tests/test.tokenSwap.ts",
-    "test-token": "./node_modules/ts-mocha/bin/ts-mocha -p ./tsconfig.json -t 1000000 tests/test.token.ts",
-    "test-freeze": "./node_modules/ts-mocha/bin/ts-mocha -p ./tsconfig.json -t 1000000 tests/test.freezeTbc.ts",
+    "test": "npm run test-all-js-library",
+    "test-all-js-library": "npx ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts",
+    "test-cs": "npx ts-mocha -p ./tsconfig.json -t 1000000 tests/test.canSwap.ts",
+    "test-tbc": "npx ts-mocha -p ./tsconfig.json -t 1000000 tests/test.tokenSwap.ts",
+    "test-token": "npx ts-mocha -p ./tsconfig.json -t 1000000 tests/test.token.ts",
+    "test-freeze": "npx ts-mocha -p ./tsconfig.json -t 1000000 tests/test.freezeTbc.ts",
     "tsc": "tsc"
   },
   "publishConfig": {


### PR DESCRIPTION
We'll want to keep an eye on practicality of this basic setup with how
slow the test suite might be.

If things are too slow and hurting our dev speed we can tweak the setup
to us to decouple the tests from the rest of the CI flow.
