### PR TITLE
decouple tx generation and tx signing/broadcasting from program fns

### DIFF
--- a/packages/ts/package.json
+++ b/packages/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rly-js",
-  "version": "0.0.10",
+  "version": "0.0.12",
   "description": "",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/packages/ts/src/programs/canonical-swap/initializeCanonicalToken.ts
+++ b/packages/ts/src/programs/canonical-swap/initializeCanonicalToken.ts
@@ -40,7 +40,7 @@ export const initializeCanonicalTxToken = async (
     walletPubKey,
     connection,
   } = {} as intitializeCanonicalTokenTxParams
-) => {
+): Promise<web3.Transaction> => {
   const transaction = new Transaction();
 
   const [expectedMintAuthorityPDA] = await PublicKey.findProgramAddress(
@@ -79,7 +79,7 @@ export const initializeCanonicalToken = async (
     connection,
     wallet,
   } = {} as intitializeCanonicalTokenParams
-) => {
+): Promise<web3.TransactionSignature> => {
   const transaction = await initializeCanonicalTxToken({
     canSwap,
     canonicalMint,

--- a/packages/ts/src/programs/canonical-swap/initializeCanonicalToken.ts
+++ b/packages/ts/src/programs/canonical-swap/initializeCanonicalToken.ts
@@ -2,6 +2,7 @@ import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import { Program, web3, Provider } from "@project-serum/anchor";
 import { config } from "../../../config";
 import { Wallet } from "@metaplex/js";
+import { sendTx, partialSignTx, addTxPayerAndHash } from "../../utils";
 const {
   pda: { CANONICAL_MINT_AUTHORITY_PDA_SEED },
   accountLayout: { CANONICAL_DATA_SPACE },
@@ -12,6 +13,15 @@ const {
   Transaction,
 } = web3;
 
+interface intitializeCanonicalTokenTxParams {
+  canSwap: Program;
+  canonicalMint: web3.PublicKey;
+  canonicalData: any;
+  canonicalAuthority: web3.PublicKey;
+  walletPubKey: web3.PublicKey;
+  connection: web3.Connection;
+}
+
 interface intitializeCanonicalTokenParams {
   canSwap: Program;
   canonicalMint: web3.PublicKey;
@@ -21,20 +31,16 @@ interface intitializeCanonicalTokenParams {
   wallet: Wallet;
 }
 
-export const initializeCanonicalToken = async (
+export const initializeCanonicalTxToken = async (
   {
     canSwap,
     canonicalMint,
     canonicalData,
     canonicalAuthority,
+    walletPubKey,
     connection,
-    wallet,
-  } = {} as intitializeCanonicalTokenParams
+  } = {} as intitializeCanonicalTokenTxParams
 ) => {
-  const provider = new Provider(connection, wallet, {
-    commitment: "confirmed",
-    preflightCommitment: "processed",
-  });
   const transaction = new Transaction();
 
   const [expectedMintAuthorityPDA] = await PublicKey.findProgramAddress(
@@ -59,5 +65,28 @@ export const initializeCanonicalToken = async (
   });
 
   transaction.add(canDataiX, initIx);
-  return provider.send(transaction, [canonicalData]);
+  await addTxPayerAndHash(transaction, connection, walletPubKey);
+  await partialSignTx(transaction, [canonicalData]);
+  return transaction;
+};
+
+export const initializeCanonicalToken = async (
+  {
+    canSwap,
+    canonicalMint,
+    canonicalData,
+    canonicalAuthority,
+    connection,
+    wallet,
+  } = {} as intitializeCanonicalTokenParams
+) => {
+  const transaction = await initializeCanonicalTxToken({
+    canSwap,
+    canonicalMint,
+    canonicalData,
+    canonicalAuthority,
+    walletPubKey: wallet.publicKey,
+    connection,
+  });
+  return sendTx(wallet, connection, transaction, { commitment: "finalized" });
 };

--- a/packages/ts/src/programs/canonical-swap/initializeWrappedToken.ts
+++ b/packages/ts/src/programs/canonical-swap/initializeWrappedToken.ts
@@ -46,7 +46,7 @@ export const initializeWrappedTokenTx = async (
     walletPubKey,
     connection,
   } = {} as initializeWrappedTokenTxParams
-) => {
+): Promise<web3.Transaction> => {
   const transaction = new Transaction();
 
   const [wrappedTokenAccount] = await PublicKey.findProgramAddress(
@@ -100,7 +100,7 @@ export const initializeWrappedToken = async (
     connection,
     wallet,
   } = {} as initializeWrappedTokenParams
-) => {
+): Promise<web3.TransactionSignature> => {
   const transaction = await initializeWrappedTokenTx({
     canSwap,
     wrappedMint,

--- a/packages/ts/src/programs/canonical-swap/initializeWrappedToken.ts
+++ b/packages/ts/src/programs/canonical-swap/initializeWrappedToken.ts
@@ -2,6 +2,7 @@ import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import { Program, web3, Provider } from "@project-serum/anchor";
 import { config } from "../../../config";
 import { Wallet } from "@metaplex/js";
+import { sendTx, partialSignTx, addTxPayerAndHash } from "../../utils";
 const {
   pda: { WRAPPED_TOKEN_OWNER_AUTHORITY_PDA_SEED, TOKEN_ACCOUNT_PDA_SEED },
   accountLayout: { WRAPPED_DATA_SPACE },
@@ -11,6 +12,17 @@ const {
   SystemProgram: { programId },
   Transaction,
 } = web3;
+
+interface initializeWrappedTokenTxParams {
+  canSwap: Program;
+  wrappedMint: web3.PublicKey;
+  wrappedData: any;
+  canonicalMint: web3.PublicKey;
+  canonicalData: web3.PublicKey;
+  canonicalAuthority: any;
+  walletPubKey: web3.PublicKey;
+  connection: web3.Connection;
+}
 
 interface initializeWrappedTokenParams {
   canSwap: Program;
@@ -23,7 +35,7 @@ interface initializeWrappedTokenParams {
   wallet: Wallet;
 }
 
-export const initializeWrappedToken = async (
+export const initializeWrappedTokenTx = async (
   {
     canSwap,
     wrappedMint,
@@ -31,14 +43,10 @@ export const initializeWrappedToken = async (
     canonicalMint,
     canonicalData,
     canonicalAuthority,
+    walletPubKey,
     connection,
-    wallet,
-  } = {} as initializeWrappedTokenParams
+  } = {} as initializeWrappedTokenTxParams
 ) => {
-  const provider = new Provider(connection, wallet, {
-    commitment: "confirmed",
-    preflightCommitment: "processed",
-  });
   const transaction = new Transaction();
 
   const [wrappedTokenAccount] = await PublicKey.findProgramAddress(
@@ -75,5 +83,34 @@ export const initializeWrappedToken = async (
   });
 
   transaction.add(wrappedDataIx, initIx);
-  return provider.send(transaction, [wrappedData]);
+  await addTxPayerAndHash(transaction, connection, walletPubKey);
+
+  await partialSignTx(transaction, [wrappedData]);
+  return transaction;
+};
+
+export const initializeWrappedToken = async (
+  {
+    canSwap,
+    wrappedMint,
+    wrappedData,
+    canonicalMint,
+    canonicalData,
+    canonicalAuthority,
+    connection,
+    wallet,
+  } = {} as initializeWrappedTokenParams
+) => {
+  const transaction = await initializeWrappedTokenTx({
+    canSwap,
+    wrappedMint,
+    wrappedData,
+    canonicalMint,
+    canonicalData,
+    canonicalAuthority,
+    walletPubKey: wallet.publicKey,
+    connection,
+  });
+
+  return sendTx(wallet, connection, transaction, { commitment: "finalized" });
 };

--- a/packages/ts/src/programs/canonical-swap/swapCanonicalForWrapped.ts
+++ b/packages/ts/src/programs/canonical-swap/swapCanonicalForWrapped.ts
@@ -2,10 +2,24 @@ import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import { Program, web3, BN, Provider } from "@project-serum/anchor";
 import { config } from "../../../config";
 import { Wallet } from "@metaplex/js";
+import { addTxPayerAndHash, sendTx } from "../../utils";
 const {
   pda: { WRAPPED_TOKEN_OWNER_AUTHORITY_PDA_SEED, TOKEN_ACCOUNT_PDA_SEED },
 } = config;
 const { PublicKey, Transaction } = web3;
+
+interface swapCanonicalForWrappedTxParams {
+  canSwap: Program;
+  canonicalMint: web3.PublicKey;
+  wrappedMint: web3.PublicKey;
+  canonicalData: web3.PublicKey;
+  wrappedData: web3.PublicKey;
+  sourceTokenAccount: web3.PublicKey;
+  destinationTokenAccount: web3.PublicKey;
+  destinationAmount: BN;
+  walletPubKey: web3.PublicKey;
+  connection: web3.Connection;
+}
 
 interface swapCanonicalForWrappedParams {
   canSwap: Program;
@@ -17,10 +31,10 @@ interface swapCanonicalForWrappedParams {
   destinationTokenAccount: web3.PublicKey;
   destinationAmount: BN;
   wallet: Wallet;
-  connection: any;
+  connection: web3.Connection;
 }
 
-export const swapCanonicalForWrapped = async (
+export const swapCanonicalForWrappedTx = async (
   {
     canSwap,
     canonicalMint,
@@ -30,14 +44,10 @@ export const swapCanonicalForWrapped = async (
     sourceTokenAccount,
     destinationTokenAccount,
     destinationAmount,
-    wallet,
+    walletPubKey,
     connection,
-  } = {} as swapCanonicalForWrappedParams
+  } = {} as swapCanonicalForWrappedTxParams
 ) => {
-  const provider = new Provider(connection, wallet, {
-    commitment: "confirmed",
-    preflightCommitment: "processed",
-  });
   const transaction = new Transaction();
 
   const [wrappedTokenAccount] = await PublicKey.findProgramAddress(
@@ -56,7 +66,7 @@ export const swapCanonicalForWrapped = async (
 
   const ix = canSwap.instruction.swapCanonicalForWrapped(destinationAmount, {
     accounts: {
-      user: wallet.publicKey,
+      user: walletPubKey,
       sourceCanonicalTokenAccount: sourceTokenAccount,
       canonicalMint: canonicalMint,
       destinationWrappedTokenAccount: destinationTokenAccount,
@@ -69,5 +79,35 @@ export const swapCanonicalForWrapped = async (
   });
 
   transaction.add(ix);
-  return provider.send(transaction, []);
+  await addTxPayerAndHash(transaction, connection, walletPubKey);
+  return transaction;
+};
+
+export const swapCanonicalForWrapped = async (
+  {
+    canSwap,
+    canonicalMint,
+    wrappedMint,
+    canonicalData,
+    wrappedData,
+    sourceTokenAccount,
+    destinationTokenAccount,
+    destinationAmount,
+    wallet,
+    connection,
+  } = {} as swapCanonicalForWrappedParams
+) => {
+  const transaction = await swapCanonicalForWrappedTx({
+    canSwap,
+    canonicalMint,
+    wrappedMint,
+    canonicalData,
+    wrappedData,
+    sourceTokenAccount,
+    destinationTokenAccount,
+    destinationAmount,
+    walletPubKey: wallet.publicKey,
+    connection,
+  });
+  return sendTx(wallet, connection, transaction, { commitment: "finalized" });
 };

--- a/packages/ts/src/programs/canonical-swap/swapCanonicalForWrapped.ts
+++ b/packages/ts/src/programs/canonical-swap/swapCanonicalForWrapped.ts
@@ -47,7 +47,7 @@ export const swapCanonicalForWrappedTx = async (
     walletPubKey,
     connection,
   } = {} as swapCanonicalForWrappedTxParams
-) => {
+): Promise<web3.Transaction> => {
   const transaction = new Transaction();
 
   const [wrappedTokenAccount] = await PublicKey.findProgramAddress(
@@ -96,7 +96,7 @@ export const swapCanonicalForWrapped = async (
     wallet,
     connection,
   } = {} as swapCanonicalForWrappedParams
-) => {
+): Promise<web3.TransactionSignature> => {
   const transaction = await swapCanonicalForWrappedTx({
     canSwap,
     canonicalMint,

--- a/packages/ts/src/programs/canonical-swap/swapWrappedForCanonical.ts
+++ b/packages/ts/src/programs/canonical-swap/swapWrappedForCanonical.ts
@@ -47,7 +47,7 @@ export const swapWrappedForCanonicalTx = async (
     walletPubKey,
     connection,
   } = {} as swapWrappedForCanonicalTxParams
-) => {
+): Promise<web3.Transaction> => {
   const transaction = new Transaction();
 
   const [expectedMintAuthorityPDA] = await web3.PublicKey.findProgramAddress(
@@ -91,7 +91,7 @@ export const swapWrappedForCanonical = async (
     wallet,
     connection,
   } = {} as swapWrappedForCanonicalParams
-) => {
+): Promise<web3.TransactionSignature> => {
   const transaction = await swapWrappedForCanonicalTx({
     canSwap,
     canonicalMint,

--- a/packages/ts/src/programs/token-swap/estimateSwap.ts
+++ b/packages/ts/src/programs/token-swap/estimateSwap.ts
@@ -17,7 +17,7 @@ interface estimateSwapParams {
   swapDestinationTokenAccount: web3.PublicKey;
   poolMintAccount: web3.PublicKey;
   poolFeeAccount: web3.PublicKey;
-  wallet: Wallet;
+  walletPubKey: web3.PublicKey;
   connection: web3.Connection;
 }
 
@@ -34,7 +34,7 @@ export const estimateSwap = async (
     swapDestinationTokenAccount,
     poolMintAccount,
     poolFeeAccount,
-    wallet,
+    walletPubKey,
     connection,
   } = {} as estimateSwapParams
 ) => {
@@ -69,7 +69,7 @@ export const estimateSwap = async (
     value: { err, logs, accounts },
   } = await simulateTransaction(
     tx,
-    wallet,
+    walletPubKey,
     connection,
     { commitment: "confirmed", preflightCommitment: "processed" },
     [userSourceTokenAccount, userDestinationTokenAccount]

--- a/packages/ts/src/programs/token-swap/executeSwap.ts
+++ b/packages/ts/src/programs/token-swap/executeSwap.ts
@@ -63,7 +63,7 @@ export const executeSwapTx = async (
     connection,
   } = {} as executeSwapTxParams,
   { userTransferAuthorityOwner } = {} as executeSwapOpts
-) => {
+): Promise<web3.Transaction> => {
   const transaction = new Transaction();
   // get exepcted swap authority PDA
 
@@ -113,7 +113,7 @@ export const executeSwap = async (
     connection,
   } = {} as executeSwapParams,
   { userTransferAuthorityOwner } = {} as executeSwapOpts
-) => {
+): Promise<web3.TransactionSignature> => {
   const transaction = await executeSwapTx(
     {
       tokenSwap,

--- a/packages/ts/src/programs/token-swap/executeSwap.ts
+++ b/packages/ts/src/programs/token-swap/executeSwap.ts
@@ -1,7 +1,7 @@
 import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import { Program, web3, BN, Provider } from "@project-serum/anchor";
 import { Wallet, NodeWallet } from "@metaplex/js";
-import { partialSignTx, sendTx } from "../../utils";
+import { partialSignTx, sendTx, addTxPayerAndHash } from "../../utils";
 const {
   PublicKey,
   SystemProgram: { programId },
@@ -88,11 +88,11 @@ export const executeSwapTx = async (
   });
 
   transaction.add(ix);
-  userTransferAuthorityOwner &&
-    (await partialSignTx(walletPubKey, connection, transaction, [
-      userTransferAuthorityOwner.payer,
-    ]));
 
+  await addTxPayerAndHash(transaction, connection, walletPubKey);
+
+  userTransferAuthorityOwner &&
+    (await partialSignTx(transaction, [userTransferAuthorityOwner.payer]));
   return transaction;
 };
 

--- a/packages/ts/src/programs/token-swap/executeSwap.ts
+++ b/packages/ts/src/programs/token-swap/executeSwap.ts
@@ -1,12 +1,28 @@
 import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import { Program, web3, BN, Provider } from "@project-serum/anchor";
 import { Wallet, NodeWallet } from "@metaplex/js";
-
+import { partialSignTx, sendTx } from "../../utils";
 const {
   PublicKey,
   SystemProgram: { programId },
   Transaction,
 } = web3;
+
+interface executeSwapTxParams {
+  tokenSwap: Program;
+  tokenSwapInfo: web3.PublicKey;
+  amountIn: BN;
+  amountOut: BN;
+  userTransferAuthority: web3.PublicKey;
+  userSourceTokenAccount: web3.PublicKey;
+  userDestinationTokenAccount: web3.PublicKey;
+  swapSourceTokenAccount: web3.PublicKey;
+  swapDestinationTokenAccount: web3.PublicKey;
+  poolMintAccount: web3.PublicKey;
+  poolFeeAccount: web3.PublicKey;
+  walletPubKey: web3.PublicKey;
+  connection: web3.Connection;
+}
 
 interface executeSwapParams {
   tokenSwap: Program;
@@ -30,7 +46,7 @@ interface executeSwapOpts {
   userTransferAuthorityOwner?: NodeWallet;
 }
 
-export const executeSwap = async (
+export const executeSwapTx = async (
   {
     tokenSwap,
     tokenSwapInfo,
@@ -43,17 +59,12 @@ export const executeSwap = async (
     swapDestinationTokenAccount,
     poolMintAccount,
     poolFeeAccount,
-    wallet,
+    walletPubKey,
     connection,
-  } = {} as executeSwapParams,
+  } = {} as executeSwapTxParams,
   { userTransferAuthorityOwner } = {} as executeSwapOpts
 ) => {
-  const provider = new Provider(connection, wallet, {
-    commitment: "confirmed",
-    preflightCommitment: "processed",
-  });
   const transaction = new Transaction();
-
   // get exepcted swap authority PDA
 
   const [expectedSwapAuthorityPDA] = await PublicKey.findProgramAddress(
@@ -77,7 +88,51 @@ export const executeSwap = async (
   });
 
   transaction.add(ix);
-  return provider.send(transaction, [
-    userTransferAuthorityOwner && userTransferAuthorityOwner.payer,
-  ]);
+  userTransferAuthorityOwner &&
+    (await partialSignTx(walletPubKey, connection, transaction, [
+      userTransferAuthorityOwner.payer,
+    ]));
+
+  return transaction;
+};
+
+export const executeSwap = async (
+  {
+    tokenSwap,
+    tokenSwapInfo,
+    amountIn,
+    amountOut,
+    userTransferAuthority,
+    userSourceTokenAccount,
+    userDestinationTokenAccount,
+    swapSourceTokenAccount,
+    swapDestinationTokenAccount,
+    poolMintAccount,
+    poolFeeAccount,
+    wallet,
+    connection,
+  } = {} as executeSwapParams,
+  { userTransferAuthorityOwner } = {} as executeSwapOpts
+) => {
+  const transaction = await executeSwapTx(
+    {
+      tokenSwap,
+      tokenSwapInfo,
+      amountIn,
+      amountOut,
+      userTransferAuthority,
+      userSourceTokenAccount,
+      userDestinationTokenAccount,
+      swapSourceTokenAccount,
+      swapDestinationTokenAccount,
+      poolMintAccount,
+      poolFeeAccount,
+      walletPubKey: wallet.publicKey,
+      connection,
+    },
+    { userTransferAuthorityOwner }
+  );
+  return sendTx(wallet, connection, transaction, {
+    commitment: "finalized",
+  });
 };

--- a/packages/ts/src/programs/token-swap/initializeLinearPriceCurve.ts
+++ b/packages/ts/src/programs/token-swap/initializeLinearPriceCurve.ts
@@ -8,6 +8,7 @@ import {
   Numberu64,
   sendTx,
   partialSignTx,
+  addTxPayerAndHash,
 } from "../../utils";
 
 const {
@@ -209,28 +210,30 @@ export const initializeLinearPriceCurveTx = async (
     initCurveIx
   );
 
+  //add tx payer and recent blockchash to setup transaction
+
+  await addTxPayerAndHash(setupTransaction, connection, walletPubKey);
+
   // partially sign setup transaction with generated accounts
 
-  setupTransaction = await partialSignTx(
-    walletPubKey,
-    connection,
-    setupTransaction,
-    [
-      poolTokenMint,
-      tokenATokenAccount,
-      tokenBTokenAccount,
-      ...(callerTokenBAccountOwner ? [callerTokenBAccountOwner.payer] : []),
-    ]
-  );
+  setupTransaction = await partialSignTx(setupTransaction, [
+    poolTokenMint,
+    tokenATokenAccount,
+    tokenBTokenAccount,
+    ...(callerTokenBAccountOwner ? [callerTokenBAccountOwner.payer] : []),
+  ]);
+
+  //add tx payer and recent blockchash to init tbc transaction
+
+  await addTxPayerAndHash(initTbcTransaction, connection, walletPubKey);
 
   //partially sign init tbc transaction with generated accounts
 
-  initTbcTransaction = await partialSignTx(
-    walletPubKey,
-    connection,
-    initTbcTransaction,
-    [tokenSwapInfo, feeAccount, destinationAccount]
-  );
+  initTbcTransaction = await partialSignTx(initTbcTransaction, [
+    tokenSwapInfo,
+    feeAccount,
+    destinationAccount,
+  ]);
 
   return { setupTransaction, initTbcTransaction };
 };

--- a/packages/ts/src/programs/token-swap/initializeLinearPriceCurve.ts
+++ b/packages/ts/src/programs/token-swap/initializeLinearPriceCurve.ts
@@ -10,12 +10,23 @@ import {
   partialSignTx,
   addTxPayerAndHash,
 } from "../../utils";
+import { JsonWebKey } from "crypto";
 
 const {
   accountLayout: { SWAP_ACCOUNT_SPACE },
 } = config;
 
 const { PublicKey, Transaction } = web3;
+
+interface initializeLinearPriceCurveTxResults {
+  setupTransaction: web3.Transaction;
+  initTbcTransaction: web3.Transaction;
+}
+
+interface initializeLinearPriceCurveResults {
+  tx: web3.TransactionSignature;
+  setupTx: web3.TransactionSignature;
+}
 
 interface initializeLinearPriceCurveTxParams {
   tokenSwap: Program;
@@ -79,7 +90,7 @@ export const initializeLinearPriceCurveTx = async (
     callerTokenBAccountOwner,
     adminAccountOwner,
   } = {} as initializeLinearPriceCurveOpts
-) => {
+): Promise<initializeLinearPriceCurveTxResults> => {
   // initialize required transactions, split into two transactions as combined the transations are > the 1232 bytes limit for solana
 
   // setupTransaction creates required accounts for tbc
@@ -260,7 +271,7 @@ export const initializeLinearPriceCurve = async (
     callerTokenBAccountOwner,
     adminAccountOwner,
   } = {} as initializeLinearPriceCurveOpts
-) => {
+): Promise<initializeLinearPriceCurveResults> => {
   const { setupTransaction, initTbcTransaction } =
     await initializeLinearPriceCurveTx(
       {

--- a/packages/ts/src/programs/token-swap/initializeLinearPriceCurve.ts
+++ b/packages/ts/src/programs/token-swap/initializeLinearPriceCurve.ts
@@ -219,7 +219,7 @@ export const initializeLinearPriceCurveTx = async (
       poolTokenMint,
       tokenATokenAccount,
       tokenBTokenAccount,
-      callerTokenBAccountOwner && callerTokenBAccountOwner.payer,
+      ...(callerTokenBAccountOwner ? [callerTokenBAccountOwner.payer] : []),
     ]
   );
 

--- a/packages/ts/src/token/addMetadata.ts
+++ b/packages/ts/src/token/addMetadata.ts
@@ -26,7 +26,7 @@ interface addMetadataParams {
 
 export const addMetadataTx = async (
   { tokenMint, tokenData, connection, walletPubKey } = {} as addMetadataTxParams
-) => {
+): Promise<web3.Transaction> => {
   const transaction = new Transaction();
 
   const metadataData = new MetadataDataData({
@@ -61,7 +61,7 @@ export const addMetadataTx = async (
 
 export const addMetadata = async (
   { tokenMint, tokenData, connection, wallet } = {} as addMetadataParams
-) => {
+): Promise<web3.TransactionSignature> => {
   const transaction = await addMetadataTx({
     tokenMint,
     tokenData,

--- a/packages/ts/src/token/createToken.ts
+++ b/packages/ts/src/token/createToken.ts
@@ -45,7 +45,7 @@ export const createToken = async (
 
   const { tokenIx, tokenMint } = await generateTokenMintInstructions(
     connection,
-    wallet,
+    wallet.publicKey,
     wallet.publicKey,
     freezeAuthority ? wallet.publicKey : null,
     tokenData.decimals

--- a/packages/ts/src/utils/index.ts
+++ b/packages/ts/src/utils/index.ts
@@ -1,309 +1,350 @@
-import { config } from "../../config"
-import { web3, BN, Provider } from '@project-serum/anchor';
+import { config } from "../../config";
+import { web3, BN, Provider } from "@project-serum/anchor";
 import * as BufferLayout from "@solana/buffer-layout";
-import { u64, AccountLayout, TOKEN_PROGRAM_ID, MintLayout, Token } from "@solana/spl-token";
+import {
+  u64,
+  AccountLayout,
+  TOKEN_PROGRAM_ID,
+  MintLayout,
+  Token,
+} from "@solana/spl-token";
 import { Wallet } from "@project-serum/anchor/dist/cjs/provider";
-const { PublicKey, SystemProgram, Keypair } = web3;
+import { Connection } from "@metaplex/js";
+const { PublicKey, SystemProgram, Keypair, sendAndConfirmRawTransaction } =
+  web3;
 
+const {
+  accountLayout: { SWAP_ACCOUNT_SPACE },
+} = config;
 
-const { accountLayout: { SWAP_ACCOUNT_SPACE } } = config;
+export const sRLY_PUBKEY = new PublicKey(
+  "RLYv2ubRMDLcGG2UyvPmnPmkfuQTsMbg4Jtygc7dmnq"
+);
 
-export const sRLY_PUBKEY = new PublicKey('RLYv2ubRMDLcGG2UyvPmnPmkfuQTsMbg4Jtygc7dmnq');
-
-
-export const getOrCreateAssociatedAccount = async (token: Token, pubKey: web3.PublicKey) => {
-
-    const accountInfo = await token.getOrCreateAssociatedAccountInfo(pubKey);
-    return accountInfo.address;
-
-}
-
-
-export const createSwapInfoAccount = async (provider: Provider, fromPubkey: web3.PublicKey, programId: web3.PublicKey) => {
-    // Generate new keypair
-
-    const newAccount = web3.Keypair.generate();
-
-
-    // Create account transaction.
-    const tx = new web3.Transaction();
-    tx.add(
-        web3.SystemProgram.createAccount({
-            fromPubkey: fromPubkey,
-            newAccountPubkey: newAccount.publicKey,
-            space: SWAP_ACCOUNT_SPACE,
-            lamports: await provider.connection.getMinimumBalanceForRentExemption(SWAP_ACCOUNT_SPACE),
-            programId
-        })
-    );
-    await provider.send(tx, [newAccount]);
-
-    return newAccount;
-}
-
-
-const publicKeyLayout = (property: string = 'publicKey'): any => {
-    return BufferLayout.blob(32, property);
+export const getOrCreateAssociatedAccount = async (
+  token: Token,
+  pubKey: web3.PublicKey
+) => {
+  const accountInfo = await token.getOrCreateAssociatedAccountInfo(pubKey);
+  return accountInfo.address;
 };
 
-const uint64Layout = (property: string = 'uint64'): any => {
-    return BufferLayout.blob(8, property);
+export const createSwapInfoAccount = async (
+  provider: Provider,
+  fromPubkey: web3.PublicKey,
+  programId: web3.PublicKey
+) => {
+  // Generate new keypair
+
+  const newAccount = web3.Keypair.generate();
+
+  // Create account transaction.
+  const tx = new web3.Transaction();
+  tx.add(
+    web3.SystemProgram.createAccount({
+      fromPubkey: fromPubkey,
+      newAccountPubkey: newAccount.publicKey,
+      space: SWAP_ACCOUNT_SPACE,
+      lamports: await provider.connection.getMinimumBalanceForRentExemption(
+        SWAP_ACCOUNT_SPACE
+      ),
+      programId,
+    })
+  );
+  await provider.send(tx, [newAccount]);
+
+  return newAccount;
 };
 
-const loadAccount = async (connection: web3.Connection, address: web3.PublicKey, programId: web3.PublicKey) => {
-    const accountInfo = await connection.getAccountInfo(address);
-    if (accountInfo === null) {
-        throw new Error('Failed to find account');
-    }
+const publicKeyLayout = (property: string = "publicKey"): any => {
+  return BufferLayout.blob(32, property);
+};
 
-    if (!accountInfo.owner.equals(programId)) {
-        throw new Error(`Invalid owner: ${JSON.stringify(accountInfo.owner)}`);
-    }
-    return Buffer.from(accountInfo.data);
-}
+const uint64Layout = (property: string = "uint64"): any => {
+  return BufferLayout.blob(8, property);
+};
+
+const loadAccount = async (
+  connection: web3.Connection,
+  address: web3.PublicKey,
+  programId: web3.PublicKey
+) => {
+  const accountInfo = await connection.getAccountInfo(address);
+  if (accountInfo === null) {
+    throw new Error("Failed to find account");
+  }
+
+  if (!accountInfo.owner.equals(programId)) {
+    throw new Error(`Invalid owner: ${JSON.stringify(accountInfo.owner)}`);
+  }
+  return Buffer.from(accountInfo.data);
+};
 
 const TokenSwapLayout = BufferLayout.struct([
-    BufferLayout.u8('version'),
-    BufferLayout.u8('isInitialized'),
-    BufferLayout.u8('bumpSeed'),
-    publicKeyLayout('tokenProgramId'),
-    publicKeyLayout('tokenAccountA'),
-    publicKeyLayout('tokenAccountB'),
-    publicKeyLayout('tokenPool'),
-    publicKeyLayout('mintA'),
-    publicKeyLayout('mintB'),
-    publicKeyLayout('feeAccount'),
-    uint64Layout('tradeFeeNumerator'),
-    uint64Layout('tradeFeeDenominator'),
-    uint64Layout('ownerTradeFeeNumerator'),
-    uint64Layout('ownerTradeFeeDenominator'),
-    uint64Layout('ownerWithdrawFeeNumerator'),
-    uint64Layout('ownerWithdrawFeeDenominator'),
-    uint64Layout('hostFeeNumerator'),
-    uint64Layout('hostFeeDenominator'),
-    BufferLayout.u8('curveType'),
-    BufferLayout.blob(32, 'curveParameters'),
+  BufferLayout.u8("version"),
+  BufferLayout.u8("isInitialized"),
+  BufferLayout.u8("bumpSeed"),
+  publicKeyLayout("tokenProgramId"),
+  publicKeyLayout("tokenAccountA"),
+  publicKeyLayout("tokenAccountB"),
+  publicKeyLayout("tokenPool"),
+  publicKeyLayout("mintA"),
+  publicKeyLayout("mintB"),
+  publicKeyLayout("feeAccount"),
+  uint64Layout("tradeFeeNumerator"),
+  uint64Layout("tradeFeeDenominator"),
+  uint64Layout("ownerTradeFeeNumerator"),
+  uint64Layout("ownerTradeFeeDenominator"),
+  uint64Layout("ownerWithdrawFeeNumerator"),
+  uint64Layout("ownerWithdrawFeeDenominator"),
+  uint64Layout("hostFeeNumerator"),
+  uint64Layout("hostFeeDenominator"),
+  BufferLayout.u8("curveType"),
+  BufferLayout.blob(32, "curveParameters"),
 ]);
 
 export class Numberu64 extends BN {
-
-    toBuffer(): Buffer {
-        const a = super.toArray().reverse();
-        const b = Buffer.from(a);
-        if (b.length === 8) {
-            return b;
-        }
-
-        const zeroPad = Buffer.alloc(8);
-        b.copy(zeroPad);
-        return zeroPad;
+  toBuffer(): Buffer {
+    const a = super.toArray().reverse();
+    const b = Buffer.from(a);
+    if (b.length === 8) {
+      return b;
     }
 
-    static fromBuffer(buffer: Buffer): Numberu64 {
-        return new Numberu64(
-            [...buffer]
-                .reverse()
-                .map(i => `00${i.toString(16)}`.slice(-2))
-                .join(''),
-            16,
-        );
-    }
+    const zeroPad = Buffer.alloc(8);
+    b.copy(zeroPad);
+    return zeroPad;
+  }
+
+  static fromBuffer(buffer: Buffer): Numberu64 {
+    return new Numberu64(
+      [...buffer]
+        .reverse()
+        .map((i) => `00${i.toString(16)}`.slice(-2))
+        .join(""),
+      16
+    );
+  }
 }
 
 export const accountInfoFromSim = async (account: any) => {
+  let data = account.data;
+  data = Buffer.from(data[0], data[1]);
+  const accountInfo = AccountLayout.decode(data);
+  accountInfo.mint = new PublicKey(accountInfo.mint);
+  accountInfo.owner = new PublicKey(accountInfo.owner);
+  accountInfo.amount = u64.fromBuffer(accountInfo.amount);
+  return accountInfo;
+};
 
-    let data = account.data;
-    data = Buffer.from(data[0], data[1]);
-    const accountInfo = AccountLayout.decode(data);
-    accountInfo.mint = new PublicKey(accountInfo.mint);
-    accountInfo.owner = new PublicKey(accountInfo.owner);
-    accountInfo.amount = u64.fromBuffer(accountInfo.amount);
-    return accountInfo;
+export const getTokenAccountInfo = async (
+  connection: web3.Connection,
+  address: web3.PublicKey
+) => {
+  const { data } = await connection.getAccountInfo(address);
+  const accountInfo = AccountLayout.decode(data);
+  accountInfo.mint = new PublicKey(accountInfo.mint);
+  accountInfo.owner = new PublicKey(accountInfo.owner);
+  accountInfo.amount = u64.fromBuffer(accountInfo.amount);
+  return accountInfo;
+};
 
-}
+export const getTokenSwapInfo = async (
+  connection: web3.Connection,
+  swapInfoPubKey: web3.PublicKey,
+  programId: web3.PublicKey
+) => {
+  const data = await loadAccount(connection, swapInfoPubKey, programId);
+  const tokenSwapData = TokenSwapLayout.decode(data);
+  if (!tokenSwapData.isInitialized) {
+    throw new Error(`Invalid token swap state`);
+  }
 
-export const getTokenAccountInfo = async (connection: web3.Connection, address: web3.PublicKey) => {
+  if (!tokenSwapData.isInitialized) {
+    throw new Error(`Invalid token swap state`);
+  }
 
-    const { data } = await connection.getAccountInfo(address);
-    const accountInfo = AccountLayout.decode(data);
-    accountInfo.mint = new PublicKey(accountInfo.mint);
-    accountInfo.owner = new PublicKey(accountInfo.owner);
-    accountInfo.amount = u64.fromBuffer(accountInfo.amount);
-    return accountInfo;
+  const [authority] = await PublicKey.findProgramAddress(
+    [swapInfoPubKey.toBuffer()],
+    programId
+  );
 
-}
+  const poolToken = new PublicKey(tokenSwapData.tokenPool);
+  const feeAccount = new PublicKey(tokenSwapData.feeAccount);
+  const tokenAccountA = new PublicKey(tokenSwapData.tokenAccountA);
+  const tokenAccountB = new PublicKey(tokenSwapData.tokenAccountB);
+  const mintA = new PublicKey(tokenSwapData.mintA);
+  const mintB = new PublicKey(tokenSwapData.mintB);
+  const tokenProgramId = new PublicKey(tokenSwapData.tokenProgramId);
 
-export const getTokenSwapInfo = async (connection: web3.Connection, swapInfoPubKey: web3.PublicKey, programId: web3.PublicKey) => {
+  const tradeFeeNumerator = Numberu64.fromBuffer(
+    tokenSwapData.tradeFeeNumerator
+  );
+  const tradeFeeDenominator = Numberu64.fromBuffer(
+    tokenSwapData.tradeFeeDenominator
+  );
+  const ownerTradeFeeNumerator = Numberu64.fromBuffer(
+    tokenSwapData.ownerTradeFeeNumerator
+  );
+  const ownerTradeFeeDenominator = Numberu64.fromBuffer(
+    tokenSwapData.ownerTradeFeeDenominator
+  );
+  const ownerWithdrawFeeNumerator = Numberu64.fromBuffer(
+    tokenSwapData.ownerWithdrawFeeNumerator
+  );
+  const ownerWithdrawFeeDenominator = Numberu64.fromBuffer(
+    tokenSwapData.ownerWithdrawFeeDenominator
+  );
+  const hostFeeNumerator = Numberu64.fromBuffer(tokenSwapData.hostFeeNumerator);
+  const hostFeeDenominator = Numberu64.fromBuffer(
+    tokenSwapData.hostFeeDenominator
+  );
+  const curveType = tokenSwapData.curveType;
 
-    const data = await loadAccount(connection, swapInfoPubKey, programId);
-    const tokenSwapData = TokenSwapLayout.decode(data);
-    if (!tokenSwapData.isInitialized) {
-        throw new Error(`Invalid token swap state`);
-    }
+  return {
+    programId,
+    tokenProgramId,
+    poolToken,
+    feeAccount,
+    authority,
+    tokenAccountA,
+    tokenAccountB,
+    mintA,
+    mintB,
+    tradeFeeNumerator,
+    tradeFeeDenominator,
+    ownerTradeFeeNumerator,
+    ownerTradeFeeDenominator,
+    ownerWithdrawFeeNumerator,
+    ownerWithdrawFeeDenominator,
+    hostFeeNumerator,
+    hostFeeDenominator,
+    curveType,
+  };
+};
 
-    if (!tokenSwapData.isInitialized) {
-        throw new Error(`Invalid token swap state`);
-    }
+export const generateTokenMintInstructions = async (
+  connection: web3.Connection,
+  walletPubKey: web3.PublicKey,
+  authority: web3.PublicKey,
+  freezeAuthority: web3.PublicKey | null,
+  decimals: number
+) => {
+  const tokenMint = Keypair.generate();
+  const balanceNeeded = await Token.getMinBalanceRentForExemptMint(connection);
 
-    const [authority] = await PublicKey.findProgramAddress(
-        [swapInfoPubKey.toBuffer()],
-        programId,
-    );
-
-    const poolToken = new PublicKey(tokenSwapData.tokenPool);
-    const feeAccount = new PublicKey(tokenSwapData.feeAccount);
-    const tokenAccountA = new PublicKey(tokenSwapData.tokenAccountA);
-    const tokenAccountB = new PublicKey(tokenSwapData.tokenAccountB);
-    const mintA = new PublicKey(tokenSwapData.mintA);
-    const mintB = new PublicKey(tokenSwapData.mintB);
-    const tokenProgramId = new PublicKey(tokenSwapData.tokenProgramId);
-
-    const tradeFeeNumerator = Numberu64.fromBuffer(
-        tokenSwapData.tradeFeeNumerator,
-    );
-    const tradeFeeDenominator = Numberu64.fromBuffer(
-        tokenSwapData.tradeFeeDenominator,
-    );
-    const ownerTradeFeeNumerator = Numberu64.fromBuffer(
-        tokenSwapData.ownerTradeFeeNumerator,
-    );
-    const ownerTradeFeeDenominator = Numberu64.fromBuffer(
-        tokenSwapData.ownerTradeFeeDenominator,
-    );
-    const ownerWithdrawFeeNumerator = Numberu64.fromBuffer(
-        tokenSwapData.ownerWithdrawFeeNumerator,
-    );
-    const ownerWithdrawFeeDenominator = Numberu64.fromBuffer(
-        tokenSwapData.ownerWithdrawFeeDenominator,
-    );
-    const hostFeeNumerator = Numberu64.fromBuffer(
-        tokenSwapData.hostFeeNumerator,
-    );
-    const hostFeeDenominator = Numberu64.fromBuffer(
-        tokenSwapData.hostFeeDenominator,
-    );
-    const curveType = tokenSwapData.curveType;
-
-    return {
-        programId,
-        tokenProgramId,
-        poolToken,
-        feeAccount,
+  return {
+    tokenMint,
+    tokenIx: [
+      SystemProgram.createAccount({
+        fromPubkey: walletPubKey,
+        newAccountPubkey: tokenMint.publicKey,
+        lamports: balanceNeeded,
+        space: MintLayout.span,
+        programId: TOKEN_PROGRAM_ID,
+      }),
+      Token.createInitMintInstruction(
+        TOKEN_PROGRAM_ID,
+        tokenMint.publicKey,
+        decimals,
         authority,
-        tokenAccountA,
-        tokenAccountB,
-        mintA,
-        mintB,
-        tradeFeeNumerator,
-        tradeFeeDenominator,
-        ownerTradeFeeNumerator,
-        ownerTradeFeeDenominator,
-        ownerWithdrawFeeNumerator,
-        ownerWithdrawFeeDenominator,
-        hostFeeNumerator,
-        hostFeeDenominator,
-        curveType,
-    }
-}
+        freezeAuthority
+      ),
+    ],
+  };
+};
 
-export const generateTokenMintInstructions = async (connection: web3.Connection, wallet: Wallet, authority: web3.PublicKey, freezeAuthority: web3.PublicKey | null, decimals: number) => {
+export const generateCreateTokenAccountInstructions = async (
+  connection: web3.Connection,
+  walletPubKey: web3.PublicKey,
+  mint: web3.PublicKey,
+  owner: web3.PublicKey
+) => {
+  const tokenAccount = Keypair.generate();
+  const balanceNeeded = await Token.getMinBalanceRentForExemptAccount(
+    connection
+  );
 
-    const tokenMint = Keypair.generate();
-    const balanceNeeded = await Token.getMinBalanceRentForExemptMint(connection);
+  return {
+    tokenAccount,
+    accountIx: [
+      SystemProgram.createAccount({
+        fromPubkey: walletPubKey,
+        newAccountPubkey: tokenAccount.publicKey,
+        lamports: balanceNeeded,
+        space: AccountLayout.span,
+        programId: TOKEN_PROGRAM_ID,
+      }),
+      Token.createInitAccountInstruction(
+        TOKEN_PROGRAM_ID,
+        mint,
+        tokenAccount.publicKey,
+        owner
+      ),
+    ],
+  };
+};
 
-    return {
-        tokenMint,
-        tokenIx: [
-            SystemProgram.createAccount({
-                fromPubkey: wallet.publicKey,
-                newAccountPubkey: tokenMint.publicKey,
-                lamports: balanceNeeded,
-                space: MintLayout.span,
-                programId: TOKEN_PROGRAM_ID
-            }),
-            Token.createInitMintInstruction(
-                TOKEN_PROGRAM_ID,
-                tokenMint.publicKey,
-                decimals,
-                authority,
-                freezeAuthority
-            )
-        ]
-    }
-}
+export const simulateTransaction = async (
+  tx: any,
+  wallet: Wallet,
+  connection: web3.Connection,
+  opts: any,
+  includeAccounts: web3.PublicKey[]
+) => {
+  tx.feePayer = wallet.publicKey;
+  tx.recentBlockhash = (
+    await connection.getRecentBlockhash(opts.preflightCommitment)
+  ).blockhash;
 
-export const generateCreateTokenAccountInstructions = async (connection: web3.Connection, wallet: Wallet, mint: web3.PublicKey, owner: web3.PublicKey) => {
-
-    const tokenAccount = Keypair.generate();
-    const balanceNeeded = await Token.getMinBalanceRentForExemptAccount(connection);
-
-    return {
-        tokenAccount,
-        accountIx: [
-            SystemProgram.createAccount({
-                fromPubkey: wallet.publicKey,
-                newAccountPubkey: tokenAccount.publicKey,
-                lamports: balanceNeeded,
-                space: AccountLayout.span,
-                programId: TOKEN_PROGRAM_ID
-            }),
-            Token.createInitAccountInstruction(
-                TOKEN_PROGRAM_ID,
-                mint,
-                tokenAccount.publicKey,
-                owner
-            )
-        ]
-    }
-}
-
-export const simulateTransaction = async (tx: any, wallet: Wallet, connection: web3.Connection, opts: any, includeAccounts: web3.PublicKey[]) => {
-
-
-    tx.feePayer = wallet.publicKey;
-    tx.recentBlockhash = (
-        await connection.getRecentBlockhash(
-            opts.preflightCommitment
-        )
-    ).blockhash;
-
+  // @ts-ignore
+  tx.recentBlockhash = await connection._recentBlockhash(
     // @ts-ignore
-    tx.recentBlockhash = await connection._recentBlockhash(
-        // @ts-ignore
-        connection._disableBlockhashCaching
-    );
+    connection._disableBlockhashCaching
+  );
 
-    const commitment = opts.commitment ?? "processed";
+  const commitment = opts.commitment ?? "processed";
 
-    const message = tx._compile();
-    const signData = tx.serializeMessage();
-    // @ts-ignore
-    const wireTransaction = tx._serialize(signData);
-    const encodedTransaction = wireTransaction.toString("base64");
-    const config: any = { encoding: "base64", commitment };
+  const message = tx._compile();
+  const signData = tx.serializeMessage();
+  // @ts-ignore
+  const wireTransaction = tx._serialize(signData);
+  const encodedTransaction = wireTransaction.toString("base64");
+  const config: any = { encoding: "base64", commitment };
 
-    if (includeAccounts) {
-        const addresses = (
-            Array.isArray(includeAccounts)
-                ? includeAccounts
-                : message.nonProgramIds()
-            // @ts-ignore
-        ).map(key => key.toBase58());
+  if (includeAccounts) {
+    const addresses = (
+      Array.isArray(includeAccounts) ? includeAccounts : message.nonProgramIds()
+    )
+      // @ts-ignore
+      .map((key) => key.toBase58());
 
-        config['accounts'] = {
-            encoding: 'base64',
-            addresses,
-        };
-    }
+    config["accounts"] = {
+      encoding: "base64",
+      addresses,
+    };
+  }
 
-    const args = [encodedTransaction, config];
+  const args = [encodedTransaction, config];
 
-    // @ts-ignore
-    const res = await connection._rpcRequest("simulateTransaction", args);
-    if (res.error) {
-        throw new Error("failed to simulate transaction: " + res.error.message);
-    }
-    return res.result;
+  // @ts-ignore
+  const res = await connection._rpcRequest("simulateTransaction", args);
+  if (res.error) {
+    throw new Error("failed to simulate transaction: " + res.error.message);
+  }
+  return res.result;
+};
 
-}
+export const sendTx = async (
+  wallet: Wallet,
+  connection: Connection,
+  transaction: web3.Transaction
+) => {
+  await wallet.signTransaction(transaction);
+  const rawTx = transaction.serialize();
 
+  return await sendAndConfirmRawTransaction(connection, rawTx, {
+    commitment: "confirmed",
+    preflightCommitment: "processed",
+  });
+};

--- a/packages/ts/src/utils/index.ts
+++ b/packages/ts/src/utils/index.ts
@@ -335,19 +335,23 @@ export const simulateTransaction = async (
   return res.result;
 };
 
-//partially sign tx with array of Keypairs
-export const partialSignTx = async (
-  walletPubKey: web3.PublicKey,
-  connection: Connection,
+export const addTxPayerAndHash = async (
   transaction: web3.Transaction,
-  signers: web3.Keypair[]
+  connection: web3.Connection,
+  payer: web3.PublicKey
 ) => {
   // add fee payer and recent block hash to tx
-  transaction.feePayer = walletPubKey;
+  transaction.feePayer = payer;
   transaction.recentBlockhash = (
     await connection.getRecentBlockhash()
   ).blockhash;
+};
 
+//partially sign tx with array of Keypairs
+export const partialSignTx = async (
+  transaction: web3.Transaction,
+  signers: web3.Keypair[]
+) => {
   // partially sign setup transaction with generated accounts
 
   transaction.partialSign(...signers);
@@ -362,6 +366,7 @@ export const sendTx = async (
   txOpts: web3.ConfirmOptions
 ) => {
   await wallet.signTransaction(transaction);
+
   const rawTx = transaction.serialize();
   return await sendAndConfirmRawTransaction(connection, rawTx, txOpts);
 };

--- a/packages/ts/src/utils/index.ts
+++ b/packages/ts/src/utils/index.ts
@@ -365,6 +365,7 @@ export const sendTx = async (
   transaction: web3.Transaction,
   txOpts: web3.ConfirmOptions
 ) => {
+  //sign tx with wallet
   await wallet.signTransaction(transaction);
 
   const rawTx = transaction.serialize();

--- a/packages/ts/src/utils/index.ts
+++ b/packages/ts/src/utils/index.ts
@@ -287,12 +287,12 @@ export const generateCreateTokenAccountInstructions = async (
 
 export const simulateTransaction = async (
   tx: any,
-  wallet: Wallet,
+  walletPubKey: web3.PublicKey,
   connection: web3.Connection,
   opts: any,
   includeAccounts: web3.PublicKey[]
 ) => {
-  tx.feePayer = wallet.publicKey;
+  tx.feePayer = walletPubKey;
   tx.recentBlockhash = (
     await connection.getRecentBlockhash(opts.preflightCommitment)
   ).blockhash;

--- a/packages/ts/src/utils/index.ts
+++ b/packages/ts/src/utils/index.ts
@@ -335,16 +335,33 @@ export const simulateTransaction = async (
   return res.result;
 };
 
+//partially sign tx with array of Keypairs
+export const partialSignTx = async (
+  walletPubKey: web3.PublicKey,
+  connection: Connection,
+  transaction: web3.Transaction,
+  signers: web3.Keypair[]
+) => {
+  // add fee payer and recent block hash to tx
+  transaction.feePayer = walletPubKey;
+  transaction.recentBlockhash = (
+    await connection.getRecentBlockhash()
+  ).blockhash;
+
+  // partially sign setup transaction with generated accounts
+
+  transaction.partialSign(...signers);
+  return transaction;
+};
+
+//sign tx with given wallet and broadcast tx
 export const sendTx = async (
   wallet: Wallet,
   connection: Connection,
-  transaction: web3.Transaction
+  transaction: web3.Transaction,
+  txOpts: web3.ConfirmOptions
 ) => {
   await wallet.signTransaction(transaction);
   const rawTx = transaction.serialize();
-
-  return await sendAndConfirmRawTransaction(connection, rawTx, {
-    commitment: "confirmed",
-    preflightCommitment: "processed",
-  });
+  return await sendAndConfirmRawTransaction(connection, rawTx, txOpts);
 };

--- a/packages/ts/tests/test.freezeTbc.ts
+++ b/packages/ts/tests/test.freezeTbc.ts
@@ -1,162 +1,189 @@
+import assert from "assert";
+const chai = require("chai");
+const expect = chai.expect;
+chai.use(require("chai-as-promised"));
 
-import assert from 'assert';
-const chai = require('chai')
-const expect = chai.expect
-chai.use(require('chai-as-promised'))
-
-import { web3, Provider, BN } from "@project-serum/anchor"
+import { web3, Provider, BN } from "@project-serum/anchor";
 import { NodeWallet } from "@metaplex/js";
 
-import { initializeLinearPriceCurve, executeSwap, tokenSwapProgram, Numberu64, getTokenSwapInfo, getMintInfo, getTokenAccountInfo } from "../src";
+import {
+  initializeLinearPriceCurve,
+  executeSwap,
+  tokenSwapProgram,
+  Numberu64,
+  getTokenSwapInfo,
+  getMintInfo,
+  getTokenAccountInfo,
+} from "../src";
 
 import { Token, TOKEN_PROGRAM_ID } from "@solana/spl-token";
-import { token } from '@project-serum/anchor/dist/cjs/utils';
+import { token } from "@project-serum/anchor/dist/cjs/utils";
 const { Keypair, Connection, clusterApiUrl, LAMPORTS_PER_SOL } = web3;
 
-describe('test freeze', () => {
+describe("test freeze", () => {
+  let provider;
+  let wallet;
+  let connection;
+  let tokenA;
+  let tokenB;
+  let tokenSwapInfo;
+  let slopeNumerator;
+  let slopeDenominator;
+  let initialTokenAPriceNumerator;
+  let initialTokenAPriceDenominator;
+  let feeAccount;
+  let poolToken;
+  let tokenATokenAccount;
+  let tokenBTokenAccount;
+  let callerTokenAAccount;
+  let callerTokenBAccount;
+  const initialTokenBLiquidity = new BN(200 * 10 ** 8);
+  const initialTokenALiquidity = new BN(10000 * 10 ** 8);
+  const swapInitAmountTokenA = new BN(2400 * 10 ** 8);
+  const decimals = 8;
 
-    let provider;
-    let wallet;
-    let connection;
-    let tokenA;
-    let tokenB;
-    let tokenSwapInfo;
-    let slopeNumerator;
-    let slopeDenominator;
-    let initialTokenAPriceNumerator;
-    let initialTokenAPriceDenominator;
-    let feeAccount;
-    let poolToken;
-    let tokenATokenAccount;
-    let tokenBTokenAccount;
-    let callerTokenAAccount;
-    let callerTokenBAccount;
-    const initialTokenBLiquidity = new BN(200 * 10 ** 8);
-    const initialTokenALiquidity = new BN(10000 * 10 ** 8);
-    const swapInitAmountTokenA = new BN(2400 * 10 ** 8);
-    const decimals = 8
+  before(async () => {
+    const walletKeyPair = Keypair.generate();
+    tokenSwapInfo = Keypair.generate();
+    provider = new Provider(
+      new Connection(clusterApiUrl("devnet")),
+      new NodeWallet(walletKeyPair),
+      {}
+    );
+    ({ connection, wallet } = provider);
+    const { payer } = wallet;
+    await connection.confirmTransaction(
+      await connection.requestAirdrop(wallet.publicKey, LAMPORTS_PER_SOL)
+    );
 
-    before(async () => {
-        const walletKeyPair = Keypair.generate();
-        tokenSwapInfo = Keypair.generate();
-        provider = new Provider(new Connection(clusterApiUrl("devnet")), new NodeWallet(walletKeyPair), {});
-        ({ connection, wallet } = provider);
-        const { payer } = wallet;
-        await connection.confirmTransaction(await connection.requestAirdrop(wallet.publicKey, LAMPORTS_PER_SOL))
+    // create token A
 
-        // create token A
+    tokenA = await Token.createMint(
+      connection,
+      payer,
+      payer.publicKey,
+      payer.publicKey,
+      decimals,
+      TOKEN_PROGRAM_ID
+    );
 
-        tokenA = await Token.createMint(
-            connection,
-            payer,
-            payer.publicKey,
-            payer.publicKey,
-            decimals,
-            TOKEN_PROGRAM_ID
-        );
+    // create token B
 
-        // create token B
+    tokenB = await Token.createMint(
+      connection,
+      payer,
+      payer.publicKey,
+      null,
+      decimals,
+      TOKEN_PROGRAM_ID
+    );
 
-        tokenB = await Token.createMint(
-            connection,
-            payer,
-            payer.publicKey,
-            null,
-            decimals,
-            TOKEN_PROGRAM_ID
-        );
+    // create token a token account for caller
 
-        // create token a token account for caller
+    callerTokenAAccount = await tokenA.createAssociatedTokenAccount(
+      payer.publicKey
+    );
 
-        callerTokenAAccount = await tokenA.createAssociatedTokenAccount(payer.publicKey);
+    // creat token b token account for caller
 
-        // creat token b token account for caller
+    callerTokenBAccount = await tokenB.createAssociatedTokenAccount(
+      payer.publicKey
+    );
 
-        callerTokenBAccount = await tokenB.createAssociatedTokenAccount(payer.publicKey);
+    // mint initial supply of token a to caller
+    await tokenA.mintTo(
+      callerTokenAAccount,
+      payer,
+      [],
+      initialTokenALiquidity.toNumber()
+    );
 
+    // mint initial supply of token b to caller
+    await tokenB.mintTo(
+      callerTokenBAccount,
+      payer,
+      [],
+      Numberu64.fromBuffer(initialTokenBLiquidity.toBuffer("le", 8))
+    );
+  });
 
-        // mint initial supply of token a to caller
-        await tokenA.mintTo(callerTokenAAccount, payer, [], initialTokenALiquidity.toNumber());
+  it("it should initiliaze a linear price curve", async () => {
+    const { payer } = wallet;
+    slopeNumerator = new BN(1);
+    slopeDenominator = new BN(200000000);
+    initialTokenAPriceNumerator = new BN(150);
+    initialTokenAPriceDenominator = new BN(3);
 
+    const tokenSwap = await tokenSwapProgram(provider);
+    const poolTokenDecimals = 9;
 
-        // mint initial supply of token b to caller
-        await tokenB.mintTo(callerTokenBAccount, payer, [], Numberu64.fromBuffer(initialTokenBLiquidity.toBuffer('le', 8)));
-    })
+    const { tx } = await initializeLinearPriceCurve(
+      {
+        tokenSwap,
+        slopeNumerator,
+        slopeDenominator,
+        initialTokenAPriceNumerator,
+        initialTokenAPriceDenominator,
+        callerTokenBAccount: callerTokenBAccount,
+        tokenSwapInfo,
+        tokenA: tokenA.publicKey,
+        tokenB: tokenB.publicKey,
+        poolTokenDecimals,
+        wallet,
+        connection,
+        initialTokenBLiquidity,
+      },
+      {}
+    );
 
-    it('it should initiliaze a linear price curve', async () => {
+    await connection.confirmTransaction(tx);
 
-        const { payer } = wallet
-        slopeNumerator = new BN(1);
-        slopeDenominator = new BN(200000000);
-        initialTokenAPriceNumerator = new BN(150);
-        initialTokenAPriceDenominator = new BN(3);
+    const data = await getTokenSwapInfo(
+      connection,
+      tokenSwapInfo.publicKey,
+      tokenSwap.programId
+    );
+    poolToken = new Token(connection, data.poolToken, TOKEN_PROGRAM_ID, payer);
+    feeAccount = data.feeAccount;
+    tokenATokenAccount = data.tokenAccountA;
+    tokenBTokenAccount = data.tokenAccountB;
+    const { amount: feeAmount } = await poolToken.getAccountInfo(feeAccount);
+    const { amount: tokenBTokenAccountAmount } = await tokenB.getAccountInfo(
+      tokenBTokenAccount
+    );
 
-        const tokenSwap = await tokenSwapProgram(provider);
-        const poolTokenDecimals = 9;
+    assert.ok(tokenBTokenAccountAmount.eq(initialTokenBLiquidity));
+    assert.ok(feeAmount.eq(new BN(0)));
+  });
 
-        const { tx, destinationAccount } = await initializeLinearPriceCurve({
-            tokenSwap,
-            slopeNumerator,
-            slopeDenominator,
-            initialTokenAPriceNumerator,
-            initialTokenAPriceDenominator,
-            callerTokenBAccount: callerTokenBAccount,
-            tokenSwapInfo,
-            tokenA: tokenA.publicKey,
-            tokenB: tokenB.publicKey,
-            poolTokenDecimals,
-            wallet,
-            connection,
-            initialTokenBLiquidity
-        }, {})
+  it("should freeze the initialized token swap token account", async () => {
+    const { payer } = wallet;
+    await tokenA.freezeAccount(tokenATokenAccount, payer.publicKey, []);
+    const acctInfo = await getTokenAccountInfo(connection, tokenATokenAccount);
+    assert.equal(acctInfo.state, 2);
+  });
 
-        await connection.confirmTransaction(tx);
+  it("should fail to execute swap", async () => {
+    const tokenSwap = await tokenSwapProgram(provider);
+    const amountOut = new BN(0);
 
-        const data = await getTokenSwapInfo(connection, tokenSwapInfo.publicKey, tokenSwap.programId);
-        poolToken = new Token(connection, data.poolToken, TOKEN_PROGRAM_ID, payer)
-        feeAccount = data.feeAccount;
-        tokenATokenAccount = data.tokenAccountA;
-        tokenBTokenAccount = data.tokenAccountB;
-        const { amount: feeAmount } = await poolToken.getAccountInfo(feeAccount);
-        const { amount: destinationAmount } = await poolToken.getAccountInfo(destinationAccount.publicKey)
-        const { amount: tokenBTokenAccountAmount } = await tokenB.getAccountInfo(tokenBTokenAccount);
-
-        assert.ok(tokenBTokenAccountAmount.eq(initialTokenBLiquidity))
-        assert.ok(feeAmount.eq(new BN(0)));
-        assert.ok(destinationAmount.eq(new BN(10 * 10 ** 8)));
-
-    })
-
-    it('should freeze the initialized token swap token account', async () => {
-
-        const { payer } = wallet
-        await tokenA.freezeAccount(tokenATokenAccount, payer.publicKey, []);
-        const acctInfo = await getTokenAccountInfo(connection, tokenATokenAccount);
-        assert.equal(acctInfo.state, 2);
-
-    })
-
-    it('should fail to execute swap', async () => {
-
-        const tokenSwap = await tokenSwapProgram(provider);
-        const amountOut = new BN(0)
-
-        const fail = executeSwap({
-            tokenSwap,
-            tokenSwapInfo: tokenSwapInfo.publicKey,
-            amountIn: swapInitAmountTokenA,
-            amountOut,
-            userTransferAuthority: wallet.publicKey,
-            userSourceTokenAccount: callerTokenAAccount,
-            userDestinationTokenAccount: callerTokenBAccount,
-            swapSourceTokenAccount: tokenATokenAccount,
-            swapDestinationTokenAccount: tokenBTokenAccount,
-            poolMintAccount: poolToken.publicKey,
-            poolFeeAccount: feeAccount,
-            wallet,
-            connection
-        })
-        await expect(fail).to.eventually.be.rejectedWith("failed to send transaction: Transaction simulation failed: Error processing Instruction 0: custom program error: 0x11");
-
-    })
-})
+    const fail = executeSwap({
+      tokenSwap,
+      tokenSwapInfo: tokenSwapInfo.publicKey,
+      amountIn: swapInitAmountTokenA,
+      amountOut,
+      userTransferAuthority: wallet.publicKey,
+      userSourceTokenAccount: callerTokenAAccount,
+      userDestinationTokenAccount: callerTokenBAccount,
+      swapSourceTokenAccount: tokenATokenAccount,
+      swapDestinationTokenAccount: tokenBTokenAccount,
+      poolMintAccount: poolToken.publicKey,
+      poolFeeAccount: feeAccount,
+      wallet,
+      connection,
+    });
+    await expect(fail).to.eventually.be.rejectedWith(
+      "failed to send transaction: Transaction simulation failed: Error processing Instruction 0: custom program error: 0x11"
+    );
+  });
+});

--- a/packages/ts/tests/test.tokenSwap.ts
+++ b/packages/ts/tests/test.tokenSwap.ts
@@ -1,275 +1,309 @@
+import assert from "assert";
 
-import assert from 'assert';
-
-import { web3, Provider, BN } from "@project-serum/anchor"
+import { web3, Provider, BN } from "@project-serum/anchor";
 import { NodeWallet } from "@metaplex/js";
-import { initializeLinearPriceCurve, executeSwap, estimateSwap, tokenSwapProgram, Numberu64, getTokenSwapInfo } from "../src";
+import {
+  initializeLinearPriceCurve,
+  executeSwap,
+  estimateSwap,
+  tokenSwapProgram,
+  Numberu64,
+  getTokenSwapInfo,
+} from "../src";
 
 import { Token, TOKEN_PROGRAM_ID } from "@solana/spl-token";
-const { Keypair, Connection, clusterApiUrl, LAMPORTS_PER_SOL, PublicKey } = web3;
+const { Keypair, Connection, clusterApiUrl, LAMPORTS_PER_SOL, PublicKey } =
+  web3;
 
-describe('token swap', () => {
+describe("token swap", () => {
+  let provider;
+  let wallet;
+  let connection;
+  let tokenA;
+  let tokenB;
+  let tokenSwapInfo;
+  let slopeNumerator;
+  let slopeDenominator;
+  let initialTokenAPriceNumerator;
+  let initialTokenAPriceDenominator;
+  let feeAccount;
+  let poolToken;
+  let tokenATokenAccount;
+  let tokenBTokenAccount;
+  let callerTokenAAccount;
+  let callerTokenBAccount;
+  let tokenBAdmin;
+  let tokenBAdminTokenAccount;
+  let tokenAAdminTokenAccount;
+  const initialTokenBSupply = new BN("2100000000000000");
+  const initialTokenBLiquidity = new BN("1600000000000000");
+  const initialTokenALiquidity = new BN(10000 * 10 ** 8);
+  const swapInitAmountTokenA = new BN(2400 * 10 ** 8);
+  const decimals = 8;
 
-    let provider;
-    let wallet;
-    let connection;
-    let tokenA;
-    let tokenB;
-    let tokenSwapInfo;
-    let slopeNumerator;
-    let slopeDenominator;
-    let initialTokenAPriceNumerator;
-    let initialTokenAPriceDenominator;
-    let feeAccount;
-    let poolToken;
-    let tokenATokenAccount;
-    let tokenBTokenAccount;
-    let callerTokenAAccount;
-    let callerTokenBAccount;
-    let tokenBAdmin;
-    let tokenBAdminTokenAccount;
-    let tokenAAdminTokenAccount;
-    const initialTokenBSupply = new BN('2100000000000000');
-    const initialTokenBLiquidity = new BN('1600000000000000');
-    const initialTokenALiquidity = new BN(10000 * 10 ** 8);
-    const swapInitAmountTokenA = new BN(2400 * 10 ** 8);
-    const decimals = 8
+  before(async () => {
+    const walletKeyPair = Keypair.generate();
+    tokenBAdmin = Keypair.generate();
+    tokenSwapInfo = Keypair.generate();
+    provider = new Provider(
+      new Connection(clusterApiUrl("devnet")),
+      new NodeWallet(walletKeyPair),
+      {}
+    );
+    ({ connection, wallet } = provider);
+    const { payer } = wallet;
+    await connection.confirmTransaction(
+      await connection.requestAirdrop(wallet.publicKey, LAMPORTS_PER_SOL)
+    );
 
-    before(async () => {
-        const walletKeyPair = Keypair.generate();
-        tokenBAdmin = Keypair.generate();
-        tokenSwapInfo = Keypair.generate();
-        provider = new Provider(new Connection(clusterApiUrl("devnet")), new NodeWallet(walletKeyPair), {});
-        ({ connection, wallet } = provider);
-        const { payer } = wallet;
-        await connection.confirmTransaction(await connection.requestAirdrop(wallet.publicKey, LAMPORTS_PER_SOL))
+    tokenA = await Token.createMint(
+      connection,
+      payer,
+      payer.publicKey,
+      null,
+      decimals,
+      TOKEN_PROGRAM_ID
+    );
 
-        tokenA = await Token.createMint(
-            connection,
-            payer,
-            payer.publicKey,
-            null,
-            decimals,
-            TOKEN_PROGRAM_ID
-        );
+    tokenB = await Token.createMint(
+      connection,
+      payer,
+      payer.publicKey,
+      null,
+      decimals,
+      TOKEN_PROGRAM_ID
+    );
 
+    callerTokenAAccount = await tokenA.createAssociatedTokenAccount(
+      payer.publicKey
+    );
+    callerTokenBAccount = await tokenB.createAssociatedTokenAccount(
+      payer.publicKey
+    );
+    tokenBAdminTokenAccount = await tokenB.createAssociatedTokenAccount(
+      tokenBAdmin.publicKey
+    );
+    tokenAAdminTokenAccount = await tokenA.createAssociatedTokenAccount(
+      tokenBAdmin.publicKey
+    );
+    await tokenB.mintTo(
+      callerTokenBAccount,
+      payer,
+      [],
+      Numberu64.fromBuffer(initialTokenBSupply.toBuffer("le", 8))
+    );
+    await tokenB.mintTo(
+      tokenBAdminTokenAccount,
+      payer,
+      [],
+      Numberu64.fromBuffer(initialTokenBSupply.toBuffer("le", 8))
+    );
+    await tokenA.mintTo(
+      callerTokenAAccount,
+      payer,
+      [],
+      initialTokenALiquidity.toNumber()
+    );
+    await tokenA.mintTo(
+      tokenAAdminTokenAccount,
+      payer,
+      [],
+      initialTokenALiquidity.toNumber()
+    );
+  });
 
-        tokenB = await Token.createMint(
-            connection,
-            payer,
-            payer.publicKey,
-            null,
-            decimals,
-            TOKEN_PROGRAM_ID
-        );
+  it("it should get an instance of the token swap program", async () => {
+    const programName = "token_bonding_curve";
+    const { idl } = await tokenSwapProgram(provider);
+    assert.strictEqual(idl.name, programName);
+  });
 
-        callerTokenAAccount = await tokenA.createAssociatedTokenAccount(payer.publicKey);
-        callerTokenBAccount = await tokenB.createAssociatedTokenAccount(payer.publicKey);
-        tokenBAdminTokenAccount = await tokenB.createAssociatedTokenAccount(tokenBAdmin.publicKey);
-        tokenAAdminTokenAccount = await tokenA.createAssociatedTokenAccount(tokenBAdmin.publicKey);
-        await tokenB.mintTo(callerTokenBAccount, payer, [], Numberu64.fromBuffer(initialTokenBSupply.toBuffer('le', 8)));
-        await tokenB.mintTo(tokenBAdminTokenAccount, payer, [], Numberu64.fromBuffer(initialTokenBSupply.toBuffer('le', 8)));
-        await tokenA.mintTo(callerTokenAAccount, payer, [], initialTokenALiquidity.toNumber());
-        await tokenA.mintTo(tokenAAdminTokenAccount, payer, [], initialTokenALiquidity.toNumber());
+  it("it should initiliaze a linear price curve", async () => {
+    const { payer } = wallet;
 
+    const adminOwner = Keypair.generate();
 
-    })
+    slopeNumerator = new BN(1);
+    slopeDenominator = new BN(200000000);
+    initialTokenAPriceNumerator = new BN(150);
+    initialTokenAPriceDenominator = new BN(3);
 
-    it('it should get an instance of the token swap program', async () => {
+    const tokenSwap = await tokenSwapProgram(provider);
+    const poolTokenDecimals = 9;
 
-        const programName = 'token_bonding_curve';
-        const { idl } = await tokenSwapProgram(provider);
-        assert.strictEqual(idl.name, programName);
+    const { tx } = await initializeLinearPriceCurve(
+      {
+        tokenSwap,
+        slopeNumerator,
+        slopeDenominator,
+        initialTokenAPriceNumerator,
+        initialTokenAPriceDenominator,
+        callerTokenBAccount: tokenBAdminTokenAccount,
+        tokenSwapInfo,
+        tokenA: tokenA.publicKey,
+        tokenB: tokenB.publicKey,
+        poolTokenDecimals,
+        wallet,
+        connection,
+        initialTokenBLiquidity,
+      },
 
-    })
+      {
+        callerTokenBAccountOwner: new NodeWallet(tokenBAdmin),
+        adminAccountOwner: adminOwner.publicKey,
+      }
+    );
 
+    await connection.confirmTransaction(tx);
 
-    it('it should initiliaze a linear price curve', async () => {
+    const data = await getTokenSwapInfo(
+      connection,
+      tokenSwapInfo.publicKey,
+      tokenSwap.programId
+    );
+    poolToken = new Token(connection, data.poolToken, TOKEN_PROGRAM_ID, payer);
+    feeAccount = data.feeAccount;
+    tokenATokenAccount = data.tokenAccountA;
+    tokenBTokenAccount = data.tokenAccountB;
+    const { amount: feeAmount } = await poolToken.getAccountInfo(feeAccount);
+    const { amount: tokenAccountAmount } = await tokenB.getAccountInfo(
+      tokenBTokenAccount
+    );
+    const { amount: userAccountAmount } = await tokenB.getAccountInfo(
+      tokenBAdminTokenAccount
+    );
 
-        const { payer } = wallet
+    assert.equal(
+      Numberu64.fromBuffer(tokenAccountAmount.toBuffer("le", 8)).toString(),
+      "1600000000000000"
+    );
+    assert.equal(
+      Numberu64.fromBuffer(userAccountAmount.toBuffer("le", 8)).toString(),
+      "500000000000000"
+    );
+    assert.ok(feeAmount.eq(new BN(0)));
+  });
 
-        const adminOwner = Keypair.generate();
+  it("it should estimate the result of a token swap", async () => {
+    const tokenSwap = await tokenSwapProgram(provider);
+    const amountOut = new BN(0);
 
-        slopeNumerator = new BN(1);
-        slopeDenominator = new BN(200000000);
-        initialTokenAPriceNumerator = new BN(150);
-        initialTokenAPriceDenominator = new BN(3);
+    const { amountTokenAPostSwap, amountTokenBPostSwap } = await estimateSwap({
+      tokenSwap,
+      tokenSwapInfo: tokenSwapInfo.publicKey,
+      amountIn: swapInitAmountTokenA,
+      amountOut,
+      userTransferAuthority: tokenBAdmin.publicKey,
+      userSourceTokenAccount: tokenAAdminTokenAccount,
+      userDestinationTokenAccount: tokenBAdminTokenAccount,
+      swapSourceTokenAccount: tokenATokenAccount,
+      swapDestinationTokenAccount: tokenBTokenAccount,
+      poolMintAccount: poolToken.publicKey,
+      poolFeeAccount: feeAccount,
+      wallet,
+      connection,
+    });
 
-        const tokenSwap = await tokenSwapProgram(provider);
-        const poolTokenDecimals = 9;
+    assert.ok(amountTokenAPostSwap.eq(new BN(760000000000)));
+    assert.ok(amountTokenBPostSwap.eq(new BN(500004000000000)));
+  });
 
+  it("it should execute a swap on a linear price curve", async () => {
+    const tokenSwap = await tokenSwapProgram(provider);
+    const amountOut = new BN(0);
 
-        const { tx, destinationAccount } = await initializeLinearPriceCurve({
-            tokenSwap,
-            slopeNumerator,
-            slopeDenominator,
-            initialTokenAPriceNumerator,
-            initialTokenAPriceDenominator,
-            callerTokenBAccount: tokenBAdminTokenAccount,
-            tokenSwapInfo,
-            tokenA: tokenA.publicKey,
-            tokenB: tokenB.publicKey,
-            poolTokenDecimals,
-            wallet,
-            connection,
-            initialTokenBLiquidity
-        },
+    const tx = await executeSwap(
+      {
+        tokenSwap,
+        tokenSwapInfo: tokenSwapInfo.publicKey,
+        amountIn: swapInitAmountTokenA,
+        amountOut,
+        userTransferAuthority: tokenBAdmin.publicKey,
+        userSourceTokenAccount: tokenAAdminTokenAccount,
+        userDestinationTokenAccount: tokenBAdminTokenAccount,
+        swapSourceTokenAccount: tokenATokenAccount,
+        swapDestinationTokenAccount: tokenBTokenAccount,
+        poolMintAccount: poolToken.publicKey,
+        poolFeeAccount: feeAccount,
+        wallet,
+        connection,
+      },
+      { userTransferAuthorityOwner: new NodeWallet(tokenBAdmin) }
+    );
 
-            {
-                callerTokenBAccountOwner: new NodeWallet(tokenBAdmin),
-                adminAccountOwner: adminOwner.publicKey
-            }
-        )
+    await connection.confirmTransaction(tx);
 
-        await connection.confirmTransaction(tx);
+    const userTokenAInfo = await tokenA.getAccountInfo(tokenAAdminTokenAccount);
+    const userTokenBInfo = await tokenB.getAccountInfo(tokenBAdminTokenAccount);
+    const swapTokenAInfo = await tokenA.getAccountInfo(tokenATokenAccount);
+    const swapTokenBInfo = await tokenB.getAccountInfo(tokenBTokenAccount);
 
-        const data = await getTokenSwapInfo(connection, tokenSwapInfo.publicKey, tokenSwap.programId);
-        poolToken = new Token(connection, data.poolToken, TOKEN_PROGRAM_ID, payer)
-        feeAccount = data.feeAccount;
-        tokenATokenAccount = data.tokenAccountA;
-        tokenBTokenAccount = data.tokenAccountB;
-        const { amount: feeAmount } = await poolToken.getAccountInfo(feeAccount);
-        const { amount: destinationAmount } = await poolToken.getAccountInfo(destinationAccount.publicKey)
-        const { amount: tokenAccountAmount } = await tokenB.getAccountInfo(tokenBTokenAccount);
-        const { amount: userAccountAmount } = await tokenB.getAccountInfo(tokenBAdminTokenAccount);
+    assert.ok(userTokenAInfo.amount.eq(new BN(760000000000)));
+    assert.ok(userTokenBInfo.amount.eq(new BN(`500004000000000`)));
+    assert.ok(swapTokenAInfo.amount.eq(new BN(240000000000)));
+    assert.ok(swapTokenBInfo.amount.eq(new BN(`1599996000000000`)));
+  });
 
+  it("it should estimate the reverse of a token swap", async () => {
+    const tokenSwap = await tokenSwapProgram(provider);
+    const amountOut = new BN(0);
 
-        assert.equal(Numberu64.fromBuffer(tokenAccountAmount.toBuffer('le', 8)).toString(), '1600000000000000')
-        assert.equal(Numberu64.fromBuffer(userAccountAmount.toBuffer('le', 8)).toString(), '500000000000000')
-        assert.ok(feeAmount.eq(new BN(0)));
-        assert.ok(destinationAmount.eq(new BN(10 * 10 ** 8)));
+    const {
+      amountTokenAPostSwap: userSourceTokenAmount,
+      amountTokenBPostSwap: userDestinationTokenAmount,
+    } = await estimateSwap({
+      tokenSwap,
+      tokenSwapInfo: tokenSwapInfo.publicKey,
+      amountIn: new BN(20 * 10 ** 8),
+      amountOut,
+      userTransferAuthority: tokenBAdmin.publicKey,
+      userSourceTokenAccount: tokenBAdminTokenAccount,
+      userDestinationTokenAccount: tokenAAdminTokenAccount,
+      swapSourceTokenAccount: tokenBTokenAccount,
+      swapDestinationTokenAccount: tokenATokenAccount,
+      poolMintAccount: poolToken.publicKey,
+      poolFeeAccount: feeAccount,
+      wallet,
+      connection,
+    });
 
-    })
+    assert.ok(userDestinationTokenAmount.eq(new BN(890000000000)));
+    assert.ok(userSourceTokenAmount.eq(new BN("500002000000000")));
+  });
 
+  it("it should swap back on a linear price curve", async () => {
+    const tokenSwap = await tokenSwapProgram(provider);
+    const amountOut = new BN(0);
 
-    it('it should estimate the result of a token swap', async () => {
+    const tx = await executeSwap(
+      {
+        tokenSwap,
+        tokenSwapInfo: tokenSwapInfo.publicKey,
+        amountIn: new BN(20 * 10 ** 8),
+        amountOut,
+        userTransferAuthority: tokenBAdmin.publicKey,
+        userSourceTokenAccount: tokenBAdminTokenAccount,
+        userDestinationTokenAccount: tokenAAdminTokenAccount,
+        swapSourceTokenAccount: tokenBTokenAccount,
+        swapDestinationTokenAccount: tokenATokenAccount,
+        poolMintAccount: poolToken.publicKey,
+        poolFeeAccount: feeAccount,
+        wallet,
+        connection,
+      },
+      { userTransferAuthorityOwner: new NodeWallet(tokenBAdmin) }
+    );
 
-        const tokenSwap = await tokenSwapProgram(provider);
-        const amountOut = new BN(0)
+    await connection.confirmTransaction(tx);
 
-        const { amountTokenAPostSwap, amountTokenBPostSwap } = await estimateSwap({
-            tokenSwap,
-            tokenSwapInfo: tokenSwapInfo.publicKey,
-            amountIn: swapInitAmountTokenA,
-            amountOut,
-            userTransferAuthority: tokenBAdmin.publicKey,
-            userSourceTokenAccount: tokenAAdminTokenAccount,
-            userDestinationTokenAccount: tokenBAdminTokenAccount,
-            swapSourceTokenAccount: tokenATokenAccount,
-            swapDestinationTokenAccount: tokenBTokenAccount,
-            poolMintAccount: poolToken.publicKey,
-            poolFeeAccount: feeAccount,
-            wallet,
-            connection
-        })
+    const userTokenAInfo = await tokenA.getAccountInfo(tokenAAdminTokenAccount);
+    const userTokenBInfo = await tokenB.getAccountInfo(tokenBAdminTokenAccount);
+    const swapTokenAInfo = await tokenA.getAccountInfo(tokenATokenAccount);
+    const swapTokenBInfo = await tokenB.getAccountInfo(tokenBTokenAccount);
 
-
-        assert.ok(amountTokenAPostSwap.eq(new BN(760000000000)));
-        assert.ok(amountTokenBPostSwap.eq(new BN(500004000000000)));
-
-    })
-
-    it('it should execute a swap on a linear price curve', async () => {
-
-        const tokenSwap = await tokenSwapProgram(provider);
-        const amountOut = new BN(0)
-
-        const tx = await executeSwap({
-            tokenSwap,
-            tokenSwapInfo: tokenSwapInfo.publicKey,
-            amountIn: swapInitAmountTokenA,
-            amountOut,
-            userTransferAuthority: tokenBAdmin.publicKey,
-            userSourceTokenAccount: tokenAAdminTokenAccount,
-            userDestinationTokenAccount: tokenBAdminTokenAccount,
-            swapSourceTokenAccount: tokenATokenAccount,
-            swapDestinationTokenAccount: tokenBTokenAccount,
-            poolMintAccount: poolToken.publicKey,
-            poolFeeAccount: feeAccount,
-            wallet,
-            connection
-        },
-            { userTransferAuthorityOwner: new NodeWallet(tokenBAdmin) }
-        )
-
-        await connection.confirmTransaction(tx)
-
-        const userTokenAInfo = await tokenA.getAccountInfo(tokenAAdminTokenAccount);
-        const userTokenBInfo = await tokenB.getAccountInfo(tokenBAdminTokenAccount);
-        const swapTokenAInfo = await tokenA.getAccountInfo(tokenATokenAccount);
-        const swapTokenBInfo = await tokenB.getAccountInfo(tokenBTokenAccount);
-
-        assert.ok(userTokenAInfo.amount.eq(new BN(760000000000)));
-        assert.ok(userTokenBInfo.amount.eq(new BN(`500004000000000`)));
-        assert.ok(swapTokenAInfo.amount.eq(new BN(240000000000)));
-        assert.ok(swapTokenBInfo.amount.eq(new BN(`1599996000000000`)));
-    })
-
-    it('it should estimate the reverse of a token swap', async () => {
-
-        const tokenSwap = await tokenSwapProgram(provider);
-        const amountOut = new BN(0)
-
-        const { amountTokenAPostSwap: userSourceTokenAmount, amountTokenBPostSwap: userDestinationTokenAmount } = await estimateSwap({
-            tokenSwap,
-            tokenSwapInfo: tokenSwapInfo.publicKey,
-            amountIn: new BN(20 * 10 ** 8),
-            amountOut,
-            userTransferAuthority: tokenBAdmin.publicKey,
-            userSourceTokenAccount: tokenBAdminTokenAccount,
-            userDestinationTokenAccount: tokenAAdminTokenAccount,
-            swapSourceTokenAccount: tokenBTokenAccount,
-            swapDestinationTokenAccount: tokenATokenAccount,
-            poolMintAccount: poolToken.publicKey,
-            poolFeeAccount: feeAccount,
-            wallet,
-            connection
-        })
-
-        assert.ok(userDestinationTokenAmount.eq(new BN(890000000000)));
-        assert.ok(userSourceTokenAmount.eq(new BN('500002000000000')));
-
-    })
-
-
-
-    it('it should swap back on a linear price curve', async () => {
-
-        const tokenSwap = await tokenSwapProgram(provider);
-        const amountOut = new BN(0)
-
-        const tx = await executeSwap({
-            tokenSwap,
-            tokenSwapInfo: tokenSwapInfo.publicKey,
-            amountIn: new BN(20 * 10 ** 8),
-            amountOut,
-            userTransferAuthority: tokenBAdmin.publicKey,
-            userSourceTokenAccount: tokenBAdminTokenAccount,
-            userDestinationTokenAccount: tokenAAdminTokenAccount,
-            swapSourceTokenAccount: tokenBTokenAccount,
-            swapDestinationTokenAccount: tokenATokenAccount,
-            poolMintAccount: poolToken.publicKey,
-            poolFeeAccount: feeAccount,
-            wallet,
-            connection
-        },
-            { userTransferAuthorityOwner: new NodeWallet(tokenBAdmin) }
-        )
-
-        await connection.confirmTransaction(tx)
-
-        const userTokenAInfo = await tokenA.getAccountInfo(tokenAAdminTokenAccount);
-        const userTokenBInfo = await tokenB.getAccountInfo(tokenBAdminTokenAccount);
-        const swapTokenAInfo = await tokenA.getAccountInfo(tokenATokenAccount);
-        const swapTokenBInfo = await tokenB.getAccountInfo(tokenBTokenAccount);
-
-        assert.ok(userTokenAInfo.amount.eq(new BN(890000000000)));
-        assert.ok(userTokenBInfo.amount.eq(new BN('500002000000000')));
-        assert.ok(swapTokenAInfo.amount.eq(new BN(110000000000)));
-        assert.ok(swapTokenBInfo.amount.eq(new BN('1599998000000000')));
-    })
-
-})
-
-
-
+    assert.ok(userTokenAInfo.amount.eq(new BN(890000000000)));
+    assert.ok(userTokenBInfo.amount.eq(new BN("500002000000000")));
+    assert.ok(swapTokenAInfo.amount.eq(new BN(110000000000)));
+    assert.ok(swapTokenBInfo.amount.eq(new BN("1599998000000000")));
+  });
+});

--- a/packages/ts/tests/test.tokenSwap.ts
+++ b/packages/ts/tests/test.tokenSwap.ts
@@ -147,7 +147,6 @@ describe("token swap", () => {
         connection,
         initialTokenBLiquidity,
       },
-
       {
         callerTokenBAccountOwner: new NodeWallet(tokenBAdmin),
         adminAccountOwner: adminOwner.publicKey,

--- a/packages/ts/tests/test.tokenSwap.ts
+++ b/packages/ts/tests/test.tokenSwap.ts
@@ -199,7 +199,7 @@ describe("token swap", () => {
       swapDestinationTokenAccount: tokenBTokenAccount,
       poolMintAccount: poolToken.publicKey,
       poolFeeAccount: feeAccount,
-      wallet,
+      walletPubKey: wallet.publicKey,
       connection,
     });
 
@@ -262,7 +262,7 @@ describe("token swap", () => {
       swapDestinationTokenAccount: tokenATokenAccount,
       poolMintAccount: poolToken.publicKey,
       poolFeeAccount: feeAccount,
-      wallet,
+      walletPubKey: wallet.publicKey,
       connection,
     });
 


### PR DESCRIPTION
- decouple transaction generation and transaction signing/broadcasting to support agnostic signing of transactions
- split up `initializeLinearPriceCurve` into `initializeLinearPriceCurveTx` (generates transactions and partially signs transactions with required generated accts) and `initiliazeLinearPriceCurve` (wraps initializeLinearPriceCurveTx, signs and broadcasts transactions with given wallet) 