### PR TITLE
update create token for browser compatablity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23491,7 +23491,7 @@
         "next": "12.0.10",
         "react": "17.0.2",
         "react-dom": "17.0.2",
-        "rly-js": "^0.0.13",
+        "rly-js": "0.0.13",
         "typescript": "4.5.5"
       },
       "dependencies": {

--- a/packages/examples/react/test-app/package.json
+++ b/packages/examples/react/test-app/package.json
@@ -23,7 +23,7 @@
     "next": "12.0.10",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "rly-js": "^0.0.13"
+    "rly-js": "^0.0.14"
   },
   "devDependencies": {
     "@types/node": "17.0.17",

--- a/packages/examples/react/test-app/src/components/CreateToken.tsx
+++ b/packages/examples/react/test-app/src/components/CreateToken.tsx
@@ -9,9 +9,8 @@ import {
   Stack,
   Link,
 } from "@mui/material";
-import BN from "bn.js";
 import { createToken } from "rly-js";
-import { Wallet } from "@project-serum/anchor";
+import { Wallet, BN } from "@project-serum/anchor";
 import { PublicKey } from "@solana/web3.js";
 import { EXPLORER_ROOT, NETWORK } from "../config";
 

--- a/packages/examples/react/test-app/src/components/ExecuteTbcSwap.tsx
+++ b/packages/examples/react/test-app/src/components/ExecuteTbcSwap.tsx
@@ -19,9 +19,8 @@ import {
 } from "rly-js";
 import { PublicKey } from "@solana/web3.js";
 import { EXPLORER_ROOT, NETWORK } from "../config";
-import { AnchorProvider as Provider, Wallet } from "@project-serum/anchor";
-import BN from "bn.js";
 import { getAssociatedTokenAddress, baseToDec, decToBase } from "../utils";
+import { AnchorProvider as Provider, Wallet, BN } from "@project-serum/anchor";
 
 const ExecuteTbcSwap: FC = () => {
   const { connection } = useConnection();

--- a/packages/examples/react/test-app/src/components/InitTbc.tsx
+++ b/packages/examples/react/test-app/src/components/InitTbc.tsx
@@ -90,6 +90,7 @@ const InitTbc: FC = () => {
       });
 
       const tokenSwap = await tokenSwapProgram(provider);
+
       const callerTokenBAccount = await getAssociatedTokenAddress(
         new PublicKey(tokenB),
         wallet.publicKey
@@ -98,6 +99,8 @@ const InitTbc: FC = () => {
         tokenMint: new PublicKey(tokenB),
         connection,
       });
+
+      console.log(tokenBDecimals);
 
       const result = await initializeLinearPriceCurve({
         tokenSwap,

--- a/packages/ts/package.json
+++ b/packages/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rly-js",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "",
   "main": "lib/src/index.js",
   "types": "lib/src/index.d.ts",

--- a/packages/ts/src/token/createToken.ts
+++ b/packages/ts/src/token/createToken.ts
@@ -18,6 +18,7 @@ import { TokenData } from "../types";
 import { BN, web3, Wallet } from "@project-serum/anchor";
 import { generateTokenMintInstructions, sendTx } from "../utils";
 import { partialSignTx, addTxPayerAndHash } from "../utils";
+import { text } from "stream/consumers";
 const { Transaction } = web3;
 
 interface createTokenTxResults {

--- a/packages/ts/src/token/createToken.ts
+++ b/packages/ts/src/token/createToken.ts
@@ -90,7 +90,7 @@ export const createTokenTx = async (
     tokenAccount,
     walletPubKey,
     [],
-    u64.fromBuffer(initialSupply.toBuffer("le", 8))
+    u64.fromBuffer(initialSupply.toArrayLike(Buffer, "le", 8))
   );
 
   // get metadata PDA

--- a/packages/ts/src/utils/index.ts
+++ b/packages/ts/src/utils/index.ts
@@ -355,8 +355,7 @@ export const addTxPayerAndHash = async (
   // add fee payer and recent block hash to tx
   transaction.feePayer = payer;
   const { blockhash, lastValidBlockHeight } =
-    await connection.getLatestBlockhash();
-
+    await connection.getLatestBlockhash("finalized");
   transaction.recentBlockhash = blockhash;
   transaction.lastValidBlockHeight = lastValidBlockHeight;
 


### PR DESCRIPTION
- us `toArrayLike()` instead of `toBuffer` in createToken.js to ensure compatibility with browser 
- when adding blockhash to tx, get the latest finalized blockhash so that the transaction simulation always finds it